### PR TITLE
PLT-1265 Prefer Valkey to Redis

### DIFF
--- a/radar/2025-06-17/amazon_elastic_cache_redis.md
+++ b/radar/2025-06-17/amazon_elastic_cache_redis.md
@@ -1,0 +1,8 @@
+---
+title: "Amazon ElastiCache Redis"
+ring: hold
+quadrant: platforms-and-operations
+tags: [infrastructure, aws, cache]
+departments: [engineering]
+---
+Redis is no longer open source as of v7.4, moving to source-available licenses. We recommend pausing new adoption in favor of Valkey, a fully open-source fork backed by the Linux Foundation. Valkey offers drop-in compatibility, improved performance, and better cost-efficiency on AWS.

--- a/radar/2025-06-17/amazon_elastic_cache_valkey.md
+++ b/radar/2025-06-17/amazon_elastic_cache_valkey.md
@@ -1,0 +1,10 @@
+---
+title: "Amazon ElastiCache Valkey"
+ring: adopt
+quadrant: platforms-and-operations
+tags: [infrastructure, aws, cache]
+departments: [engineering]
+---
+[Valkey](https://valkey.io/) is an open source, in-memory, high performance, key-value datastore. 
+It is a drop-in replacement for Redis OSS. 
+It can be used for a variety of workloads such as caching, session stores, and message queues, and can act as a primary database.


### PR DESCRIPTION
We are moving to Valkey over Redis, more details over [ADR](https://flaconi.atlassian.net/wiki/spaces/ENGG/pages/3855712377/ADR-3+Use+of+Valkey+instead+of+Redis+OOS)